### PR TITLE
Patch tree-view and settings scrollbars

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -183,7 +183,7 @@
 
 @progress-background-color:         @base-accent-color;
 
-@scrollbar-color:                   @level-1-color;
+@scrollbar-color:                   @base-accent-color-light;
 @scrollbar-background-color:        @level-3-color; // replaced `transparent` with a solid color to test https://github.com/atom/one-light-ui/issues/4
 @scrollbar-color-editor:            contrast(@ui-syntax-color, darken(@ui-syntax-color, 18%), lighten(@ui-syntax-color, 9%) );
 @scrollbar-background-color-editor: @ui-syntax-color;


### PR DESCRIPTION
This fixes the bug mentioned in [raindeer44/clear-night-syntax issue #2](https://github.com/Raindeer44/clear-night-syntax/issues/2). For whatever reason, the scrollbars were set to the same color as their background. Easy enough fix.